### PR TITLE
Fixes #6: adds standard `myaddinstance` capacity

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -14,6 +14,14 @@
  
         'clonepermissionsfrom' => 'moodle/site:manageblocks'
     ),
+
+    'block/filescan:myaddinstance' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => array(
+            'user' => CAP_PREVENT
+        )
+    ),
     
    'block/filescan:viewpages' => array(
         'captype' => 'read',


### PR DESCRIPTION
These may not be the permissions you want, but if they are feel free to use it as is. This basically just prevents anyone from adding this block to their dashboard. And Moodle will stop complaining about it.