### PR TITLE
Delete summary cache when file or folders are changed

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -1,0 +1,39 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+class block_filescan_observer {
+
+	// This function is called when a Moodle event may mean we need to update the filescan summary data.
+	// The summary data is cached using Moodle Cache API so that the summary does not need to be regenerated
+	// on every page load.  If a file resource or folder is created, updated, or deleted the summary data
+	// should be regenerated.  This is done by deleting the filescan cache for the course.
+	// There isn't a specific event for creating or deleting files and folders (or updating files), so
+	// we need to catch all events that create, update, or delete course modules (as well as update mod_folder)
+	// and then check to see if they match the criteria to delete the cache.
+	
+	// Note: it can take a few minutes for some of these events to fire.
+
+    public static function update(\core\event\base $event) {
+    
+    	$event_data = $event->get_data();
+          
+       	// Determine if we should invalidate the filescan cache
+       	// If file resource is affected at all
+       	// If folder is created, updated, or deleted
+       	if (
+       		(isset($event_data["eventname"]) && $event_data["eventname"]=="\\mod_folder\\event\\folder_updated") ||
+       		(isset($event_data["eventname"]) && isset($event_data["other"]) && isset($event_data["other"]["modulename"]) && $event_data["eventname"]=="\\core\\event\\course_module_deleted" && $event_data["other"]["modulename"]=="folder") ||
+       		(isset($event_data["eventname"]) && isset($event_data["other"]) && isset($event_data["other"]["modulename"]) && $event_data["eventname"]=="\\core\\event\\course_module_created" && $event_data["other"]["modulename"]=="folder") ||
+       		(isset($event_data["eventname"]) && isset($event_data["other"]) && isset($event_data["other"]["modulename"]) && $event_data["eventname"]=="\\core\\event\\course_module_deleted" && $event_data["other"]["modulename"]=="resource") ||
+       		(isset($event_data["eventname"]) && isset($event_data["other"]) && isset($event_data["other"]["modulename"]) && $event_data["eventname"]=="\\core\\event\\course_module_created" && $event_data["other"]["modulename"]=="resource") ||
+			(isset($event_data["eventname"]) && isset($event_data["other"]) && isset($event_data["other"]["modulename"]) && $event_data["eventname"]=="\\core\\event\\course_module_updated" && $event_data["other"]["modulename"]=="resource") )
+ 		{	
+ 			// Clear any existing cache data for this course 
+			$cache = cache::make('block_filescan', 'filescan');
+			$filescan_cache = $cache->delete($event_data["courseid"]); 	
+		}   
+       	
+    } 
+
+}

--- a/db/events.php
+++ b/db/events.php
@@ -1,0 +1,22 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+$observers = array (
+    array (
+        'eventname' => '\core\event\course_module_created',
+        'callback'  => 'block_filescan_observer::update',
+    ),
+    array (
+        'eventname' => '\core\event\course_module_updated',
+        'callback'  => 'block_filescan_observer::update',
+    ),
+    array (
+        'eventname' => '\core\event\course_module_deleted',
+        'callback'  => 'block_filescan_observer::update',
+    ),
+    array (
+        'eventname' => '\mod_folder\event\folder_updated',
+        'callback'  => 'block_filescan_observer::update',
+    )   
+);

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -159,7 +159,7 @@ function xmldb_block_filescan_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2017101318, 'error', 'filescan');
     }
 
-    if (/*$oldversion < X*/1) {
+    if ($oldversion < 2018073100) {
         // Update settings names to use full frankenstyle plugin name.
         $settings = array(
             'apiurl',

--- a/version.php
+++ b/version.php
@@ -1,4 +1,4 @@
 <?php
 $plugin->component = 'block_filescan'; // Declare the type and name of this plugin.
-$plugin->version = 2018080117;  // YYYYMMDDHH (year, month, day, 24-hr time)
+$plugin->version = 2018080200;  // YYYYMMDDHH (year, month, day, 24-hr time)
 $plugin->requires = 2016052300; // YYYYMMDDHH (Moodle version)


### PR DESCRIPTION
When a file or folder is created, updated, or deleted, use the Moodle Events API to invalidate the filescan cache used for the summary text.